### PR TITLE
New IEmailSender.SendEmailAsAsync method.

### DIFF
--- a/src/Losol.Communication.Email.File/FileEmailWriter.cs
+++ b/src/Losol.Communication.Email.File/FileEmailWriter.cs
@@ -3,16 +3,15 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Losol.Communication.Email.File
 {
-    /// <summary>
-    /// Writes an email to a file instead of actually sending it.
-    /// This implementation is not designed to be used in production.
-    /// </summary>
-    public class FileEmailWriter : IEmailSender
+	/// <summary>
+	/// Writes an email to a file instead of actually sending it.
+	/// This implementation is not designed to be used in production.
+	/// </summary>
+	public class FileEmailWriter : IEmailSender
     {
         private readonly IOptions<FileEmailConfig> _options;
 
@@ -33,11 +32,17 @@ namespace Losol.Communication.Email.File
             EmailMessageType messageType = EmailMessageType.Html)
         {
             // filename: {datetime}-{email}-{subject}.html
-            var filename = $"{DateTime.Now.ToString("yyyyMMdd-HHmmss")}-{address.GenerateSlug()}-{subject.GenerateSlug()}.html";
+            var filename = $"{DateTime.Now:yyyyMMdd-HHmmss}-{address.GenerateSlug()}-{subject.GenerateSlug()}.html";
 
             // Write the message to the file
             await using var outputFile = new StreamWriter(Path.Combine(_options.Value.FilePath, filename));
             await outputFile.WriteLineAsync(message);
+        }
+
+        public Task SendEmailAsAsync(string fromName, string fromEmail, string address, string subject, string message,
+            Attachment attachment = null, EmailMessageType messageType = EmailMessageType.Html)
+        {
+            return SendEmailAsync(address, subject, message, attachment, messageType);
         }
     }
 

--- a/src/Losol.Communication.Email.Mock/MockEmailSender.cs
+++ b/src/Losol.Communication.Email.Mock/MockEmailSender.cs
@@ -18,5 +18,13 @@ namespace Losol.Communication.Email.Mock
             _logger.LogInformation("Sending email with subject {subject} to {address}", subject, address);
             return Task.CompletedTask;
         }
+
+        public Task SendEmailAsAsync(string fromName, string fromEmail, string address, string subject, string message,
+            Attachment attachment = null, EmailMessageType messageType = EmailMessageType.Html)
+        {
+            _logger.LogInformation("Sending email from {{fromEmail}} <{{fromName}}> with subject {{subject}} to {{address}}",
+                fromEmail, fromName, subject, address);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Losol.Communication.Email.SendGrid/SendGridEmailSender.cs
+++ b/src/Losol.Communication.Email.SendGrid/SendGridEmailSender.cs
@@ -16,17 +16,24 @@ namespace Losol.Communication.Email.SendGrid
             _config = options.Value;
         }
 
-        public async Task SendEmailAsync(
+        public Task SendEmailAsync(
             string address,
             string subject,
             string message,
             Attachment attachment = null,
             EmailMessageType messageType = EmailMessageType.Html)
         {
+            return SendEmailAsAsync(_config.Name, _config.EmailAddress,
+                address, subject, message, attachment, messageType);
+        }
+
+        public async Task SendEmailAsAsync(string fromName, string fromEmail, string address, string subject, string message,
+            Attachment attachment = null, EmailMessageType messageType = EmailMessageType.Html)
+        {
             var client = new SendGridClient(_config.Key);
             var msg = new SendGridMessage
             {
-                From = new EmailAddress(_config.EmailAddress, _config.Name),
+                From = new EmailAddress(fromEmail, fromName),
                 Subject = subject
             };
             switch (messageType)

--- a/src/Losol.Communication.Email/IEmailSender.cs
+++ b/src/Losol.Communication.Email/IEmailSender.cs
@@ -18,6 +18,25 @@ namespace Losol.Communication.Email
             string message,
             Attachment attachment = null,
             EmailMessageType messageType = EmailMessageType.Html);
+
+        /// <summary>
+        /// Sends email with optional attachment with the explicitly defined From: fields.
+        /// </summary>
+        /// <param name="fromName">Not empty string</param>
+        /// <param name="fromEmail">Not empty email</param>
+        /// <param name="address">Email address, may contain name in a standard form Some Name &lt;some@email.com&gt;</param>
+        /// <param name="subject">Email subject</param>
+        /// <param name="message">HTML or plain text to be sent</param>
+        /// <param name="attachment">Optional email attachment</param>
+        /// <param name="messageType">Type of the given <code>message</code> data. Can be <code>Text</code> or <code>Html</code></param>
+        Task SendEmailAsAsync(
+            string fromName,
+            string fromEmail,
+            string address,
+            string subject,
+            string message,
+            Attachment attachment = null,
+            EmailMessageType messageType = EmailMessageType.Html);
     }
 
     public enum EmailMessageType

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
     <Authors>Ole Kristian Losvik</Authors>
     <Company>Losol AS</Company>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
New method is added for backward compatibility: SendEmailAsAsync.
It allows to specify from email/name.