### PR TITLE
Adding health checks to services.

### DIFF
--- a/Losol.Communication.sln
+++ b/Losol.Communication.sln
@@ -33,6 +33,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		src\common.props = src\common.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Losol.Communication.HealthCheck.Email", "src\Losol.Communication.HealthCheck.Email\Losol.Communication.HealthCheck.Email.csproj", "{0BE43DA9-4D0F-40B2-A36F-245684999B6C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Losol.Communication.HealthCheck.Sms", "src\Losol.Communication.HealthCheck.Sms\Losol.Communication.HealthCheck.Sms.csproj", "{E5DB86CB-856A-4A09-9256-8DB28A027F73}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Losol.Communication.HealthCheck.Abstractions", "src\Losol.Communication.HealthCheck.Abstractions\Losol.Communication.HealthCheck.Abstractions.csproj", "{44B20DA7-9243-42BB-AA01-B9D94FB95B53}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Losol.Communication.HealthCheck.Abstractions.Tests", "tests\Losol.Communication.HealthCheck.Abstractions.Tests\Losol.Communication.HealthCheck.Abstractions.Tests.csproj", "{385A2E30-9504-4295-850B-45F61961D9AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +159,54 @@ Global
 		{EDD51222-34F3-4A54-8C35-23C7EF583E77}.Release|x64.Build.0 = Release|Any CPU
 		{EDD51222-34F3-4A54-8C35-23C7EF583E77}.Release|x86.ActiveCfg = Release|Any CPU
 		{EDD51222-34F3-4A54-8C35-23C7EF583E77}.Release|x86.Build.0 = Release|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Release|x64.Build.0 = Release|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C}.Release|x86.Build.0 = Release|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Debug|x64.Build.0 = Debug|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Release|x64.ActiveCfg = Release|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Release|x64.Build.0 = Release|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73}.Release|x86.Build.0 = Release|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Debug|x64.Build.0 = Debug|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Debug|x86.Build.0 = Debug|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Release|x64.ActiveCfg = Release|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Release|x64.Build.0 = Release|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Release|x86.ActiveCfg = Release|Any CPU
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53}.Release|x86.Build.0 = Release|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Debug|x86.Build.0 = Debug|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Release|x64.Build.0 = Release|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{385A2E30-9504-4295-850B-45F61961D9AF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -165,6 +221,10 @@ Global
 		{AA736154-C412-4A51-9134-3576F62B9134} = {4B03ABF7-A8C8-40C2-BCA5-EE1ED6B5D5B4}
 		{294D8E54-C44A-47E4-B7EA-3487FA8213F3} = {4B03ABF7-A8C8-40C2-BCA5-EE1ED6B5D5B4}
 		{EDD51222-34F3-4A54-8C35-23C7EF583E77} = {BD1386F9-8B88-4963-8901-B6E8462A30B9}
+		{0BE43DA9-4D0F-40B2-A36F-245684999B6C} = {4B03ABF7-A8C8-40C2-BCA5-EE1ED6B5D5B4}
+		{E5DB86CB-856A-4A09-9256-8DB28A027F73} = {4B03ABF7-A8C8-40C2-BCA5-EE1ED6B5D5B4}
+		{44B20DA7-9243-42BB-AA01-B9D94FB95B53} = {4B03ABF7-A8C8-40C2-BCA5-EE1ED6B5D5B4}
+		{385A2E30-9504-4295-850B-45F61961D9AF} = {BD1386F9-8B88-4963-8901-B6E8462A30B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ED56FF45-6DFC-4630-9ADD-2E824CC10E30}

--- a/src/Losol.Communication.Email.File/FileEmailWriter.cs
+++ b/src/Losol.Communication.Email.File/FileEmailWriter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
 
 namespace Losol.Communication.Email.File
 {
@@ -16,7 +17,7 @@ namespace Losol.Communication.Email.File
     {
         private readonly IOptions<FileEmailConfig> _options;
 
-        public FileEmailWriter(IOptions<FileEmailConfig> options)
+        public FileEmailWriter(IOptions<FileEmailConfig> options, IHealthCheckStorage healthCheckStorage) : base(healthCheckStorage)
         {
             _options = options;
             if (!Directory.Exists(options.Value.FilePath))
@@ -25,7 +26,7 @@ namespace Losol.Communication.Email.File
             }
         }
 
-        public override async Task SendEmailAsync(EmailModel emailModel)
+        protected override async Task SendEmailInternalAsync(EmailModel emailModel)
         {
             emailModel.Validate();
 

--- a/src/Losol.Communication.Email.Mock/MockEmailSender.cs
+++ b/src/Losol.Communication.Email.Mock/MockEmailSender.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Losol.Communication.Email.Mock
@@ -8,12 +9,12 @@ namespace Losol.Communication.Email.Mock
     {
         private readonly ILogger<MockEmailSender> _logger;
 
-        public MockEmailSender(ILogger<MockEmailSender> logger)
+        public MockEmailSender(ILogger<MockEmailSender> logger, IHealthCheckStorage healthCheckStorage) : base(healthCheckStorage)
         {
             _logger = logger;
         }
 
-        public override Task SendEmailAsync(EmailModel emailModel)
+        protected override Task SendEmailInternalAsync(EmailModel emailModel)
         {
             _logger.LogInformation("Sending email from {{from}} with subject {{subject}} to {{address}}",
                 emailModel.From, emailModel.Subject, emailModel.Recipients.First());

--- a/src/Losol.Communication.Email/AbstractEmailSender.cs
+++ b/src/Losol.Communication.Email/AbstractEmailSender.cs
@@ -1,11 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
 
 namespace Losol.Communication.Email
 {
     public abstract class AbstractEmailSender : IEmailSender
     {
+        private readonly IHealthCheckStorage _healthCheckStorage;
+
+        protected AbstractEmailSender(IHealthCheckStorage healthCheckStorage)
+        {
+            _healthCheckStorage = healthCheckStorage ?? throw new ArgumentNullException(nameof(healthCheckStorage));
+        }
+
         public Task SendEmailAsync(
             string address,
             string subject,
@@ -37,6 +46,34 @@ namespace Losol.Communication.Email
             });
         }
 
-        public abstract Task SendEmailAsync(EmailModel emailModel);
+        public async Task SendEmailAsync(EmailModel emailModel)
+        {
+            try
+            {
+                await SendEmailInternalAsync(emailModel);
+                await _healthCheckStorage.CheckedAsync(IEmailSender.ServiceName,
+                    new HealthCheckStatus(HealthStatus.Healthy));
+            }
+            catch (EmailSenderException e)
+            {
+                await _healthCheckStorage.CheckedAsync(IEmailSender.ServiceName,
+                    new HealthCheckStatus(HealthStatus.Unhealthy, e.Message));
+                throw;
+            }
+            catch (Exception e)
+            {
+                await _healthCheckStorage.CheckedAsync(IEmailSender.ServiceName,
+                    new HealthCheckStatus(HealthStatus.Unhealthy, e.Message));
+                throw new EmailSenderException(e.Message, e);
+            }
+        }
+
+        /// <exception cref="EmailSenderException">Failed to send email</exception>
+        protected abstract Task SendEmailInternalAsync(EmailModel emailModel);
+
+        public virtual Task<HealthCheckStatus> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new HealthCheckStatus(HealthStatus.Healthy)); // Stub
+        }
     }
 }

--- a/src/Losol.Communication.Email/EmailSenderException.cs
+++ b/src/Losol.Communication.Email/EmailSenderException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Losol.Communication.Email
+{
+    public class EmailSenderException : Exception
+    {
+        public EmailSenderException(string message) : base(message)
+        {
+        }
+
+        public EmailSenderException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Losol.Communication.Email/IEmailSender.cs
+++ b/src/Losol.Communication.Email/IEmailSender.cs
@@ -1,11 +1,14 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
 
 namespace Losol.Communication.Email
 {
-    public interface IEmailSender
+    public interface IEmailSender : IHealthCheckService
     {
+        const string ServiceName = "email";
+
         /// <summary>
         /// Sends email with optional attachment.
         /// </summary>
@@ -14,6 +17,7 @@ namespace Losol.Communication.Email
         /// <param name="message">HTML or plain text to be sent</param>
         /// <param name="attachment">Optional email attachment</param>
         /// <param name="messageType">Type of the given <code>message</code> data. Can be <code>Text</code> or <code>Html</code></param>
+        /// <exception cref="EmailSenderException">Failed to send email</exception>
         [Obsolete("Use SendEmailAsync(EmailModel) instead")]
         Task SendEmailAsync(
             string address,
@@ -23,6 +27,7 @@ namespace Losol.Communication.Email
             EmailMessageType messageType = EmailMessageType.Html);
 
         /// <exception cref="ValidationException">When given <code>emailModel</code> is not valid.</exception>
+        /// <exception cref="EmailSenderException">Failed to send email</exception>
         Task SendEmailAsync(EmailModel emailModel);
     }
 }

--- a/src/Losol.Communication.Email/Losol.Communication.Email.csproj
+++ b/src/Losol.Communication.Email/Losol.Communication.Email.csproj
@@ -6,4 +6,8 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Losol.Communication.HealthCheck.Abstractions\Losol.Communication.HealthCheck.Abstractions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Losol.Communication.HealthCheck.Abstractions/AbstractPeriodicHealthCheck.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/AbstractPeriodicHealthCheck.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Losol.Communication.HealthCheck.Abstractions
+{
+    /// <summary>
+    /// Performs health check periodically. If check was recently made by the
+    /// health check service itself (like, when email is successfully sent
+    /// or failed), then the next planned check is postponed.
+    /// </summary>
+    public abstract class AbstractPeriodicHealthCheck : IHealthCheck
+    {
+        protected abstract string ServiceName { get; }
+
+        protected abstract TimeSpan CheckPeriod { get; }
+
+
+        private readonly IHealthCheckStorage _healthCheckStorage;
+        private readonly IHealthCheckService _healthCheckService;
+
+        protected AbstractPeriodicHealthCheck(IHealthCheckStorage healthCheckStorage, IHealthCheckService healthCheckService)
+        {
+            _healthCheckStorage = healthCheckStorage ?? throw new ArgumentNullException(nameof(healthCheckStorage));
+            _healthCheckService = healthCheckService ?? throw new ArgumentNullException(nameof(healthCheckService));
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+        {
+            var healthStatus = await _healthCheckStorage.GetCurrentStatusAsync(ServiceName);
+            if (healthStatus == null || healthStatus.DateTime + CheckPeriod < DateTime.UtcNow)
+            {
+                healthStatus = await _healthCheckService.CheckHealthAsync();
+                await _healthCheckStorage.CheckedAsync(ServiceName, healthStatus);
+            }
+            return healthStatus.Status switch
+            {
+                HealthStatus.Healthy => HealthCheckResult.Healthy(),
+                _ => HealthCheckResult.Unhealthy(healthStatus.ErrorMessage)
+            };
+        }
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckMemoryStorage.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckMemoryStorage.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Losol.Communication.HealthCheck.Abstractions
+{
+    public class HealthCheckMemoryStorage : IHealthCheckStorage
+    {
+        private readonly IDictionary<string, HealthCheckStatus> _checks =
+            new Dictionary<string, HealthCheckStatus>();
+
+        public Task<HealthCheckStatus> GetCurrentStatusAsync(string serviceName)
+        {
+            return Task.FromResult(_checks.ContainsKey(serviceName) ? _checks[serviceName] : null);
+        }
+
+        public Task CheckedAsync(string serviceName, HealthCheckStatus healthCheckStatus)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+            {
+                throw new ArgumentException(nameof(serviceName));
+            }
+            _checks.Add(serviceName, healthCheckStatus ?? throw new ArgumentNullException(nameof(healthCheckStatus)));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckStatus.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckStatus.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Losol.Communication.HealthCheck.Abstractions
+{
+    public class HealthCheckStatus
+    {
+        public HealthStatus Status { get; }
+
+        public DateTime DateTime { get; set; } = DateTime.UtcNow;
+
+        public string ErrorMessage { get; }
+
+        public HealthCheckStatus(HealthStatus status, string errorMessage = null)
+        {
+            Status = status;
+            ErrorMessage = errorMessage;
+        }
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Abstractions/HealthStatus.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/HealthStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace Losol.Communication.HealthCheck.Abstractions
+{
+    public enum HealthStatus
+    {
+        Unhealthy = 0,
+        Healthy = 1
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Abstractions/IHealthCheckService.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/IHealthCheckService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Losol.Communication.HealthCheck.Abstractions
+{
+    public interface IHealthCheckService
+    {
+        Task<HealthCheckStatus> CheckHealthAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Abstractions/IHealthCheckStorage.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/IHealthCheckStorage.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace Losol.Communication.HealthCheck.Abstractions
+{
+    public interface IHealthCheckStorage
+    {
+        Task<HealthCheckStatus> GetCurrentStatusAsync(string serviceName);
+
+        Task CheckedAsync(string serviceName, HealthCheckStatus healthCheckStatus);
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Abstractions/Losol.Communication.HealthCheck.Abstractions.csproj
+++ b/src/Losol.Communication.HealthCheck.Abstractions/Losol.Communication.HealthCheck.Abstractions.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../common.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Losol.Communication.HealthCheck.Email/EmailHealthCheck.cs
+++ b/src/Losol.Communication.HealthCheck.Email/EmailHealthCheck.cs
@@ -1,0 +1,23 @@
+﻿using Losol.Communication.Email;
+using Losol.Communication.HealthCheck.Abstractions;
+using Microsoft.Extensions.Options;
+using System;
+
+namespace Losol.Communication.HealthCheck.Email
+{
+    public class EmailHealthCheck : AbstractPeriodicHealthCheck
+    {
+        private readonly IOptions<EmailHealthCheckSettings> _options;
+
+        protected override string ServiceName => IEmailSender.ServiceName;
+        protected override TimeSpan CheckPeriod => _options.Value.CheckPeriod;
+
+        public EmailHealthCheck(
+            IOptions<EmailHealthCheckSettings> options,
+            IHealthCheckStorage healthCheckStorage,
+            IEmailSender emailSender) : base(healthCheckStorage, emailSender)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Email/EmailHealthCheckSettings.cs
+++ b/src/Losol.Communication.HealthCheck.Email/EmailHealthCheckSettings.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Losol.Communication.HealthCheck.Email
+{
+    public class EmailHealthCheckSettings
+    {
+        public TimeSpan CheckPeriod { get; set; }
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Email/Losol.Communication.HealthCheck.Email.csproj
+++ b/src/Losol.Communication.HealthCheck.Email/Losol.Communication.HealthCheck.Email.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../common.props" />
 
   <ItemGroup>
+    <ProjectReference Include="..\Losol.Communication.Email\Losol.Communication.Email.csproj" />
     <ProjectReference Include="..\Losol.Communication.HealthCheck.Abstractions\Losol.Communication.HealthCheck.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Losol.Communication.HealthCheck.Sms/Losol.Communication.HealthCheck.Sms.csproj
+++ b/src/Losol.Communication.HealthCheck.Sms/Losol.Communication.HealthCheck.Sms.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../common.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\Losol.Communication.HealthCheck.Abstractions\Losol.Communication.HealthCheck.Abstractions.csproj" />
+    <ProjectReference Include="..\Losol.Communication.Sms\Losol.Communication.Sms.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Losol.Communication.HealthCheck.Sms/SmsHealthCheck.cs
+++ b/src/Losol.Communication.HealthCheck.Sms/SmsHealthCheck.cs
@@ -1,0 +1,23 @@
+﻿using Losol.Communication.HealthCheck.Abstractions;
+using Losol.Communication.Sms;
+using Microsoft.Extensions.Options;
+using System;
+
+namespace Losol.Communication.HealthCheck.Sms
+{
+    public class SmsHealthCheck : AbstractPeriodicHealthCheck
+    {
+        private readonly IOptions<SmsHealthCheckSettings> _options;
+
+        protected override string ServiceName => ISmsSender.ServiceName;
+        protected override TimeSpan CheckPeriod => _options.Value.CheckPeriod;
+
+        public SmsHealthCheck(
+            IOptions<SmsHealthCheckSettings> options,
+            IHealthCheckStorage healthCheckStorage,
+            ISmsSender smsSender) : base(healthCheckStorage, smsSender)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+    }
+}

--- a/src/Losol.Communication.HealthCheck.Sms/SmsHealthCheckSettings.cs
+++ b/src/Losol.Communication.HealthCheck.Sms/SmsHealthCheckSettings.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Losol.Communication.HealthCheck.Sms
+{
+    public class SmsHealthCheckSettings
+    {
+        public TimeSpan CheckPeriod { get; set; }
+    }
+}

--- a/src/Losol.Communication.Sms.Mock/MockSmsSender.cs
+++ b/src/Losol.Communication.Sms.Mock/MockSmsSender.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Losol.Communication.Sms.Mock
@@ -16,6 +18,11 @@ namespace Losol.Communication.Sms.Mock
         {
             _logger.LogInformation("Sending SMS with text \"{body}\" to {to}", body, to);
             return Task.CompletedTask;
+        }
+
+        public Task<HealthCheckStatus> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new HealthCheckStatus(HealthStatus.Healthy));
         }
     }
 }

--- a/src/Losol.Communication.Sms.Twilio/TwilioSmsSender.cs
+++ b/src/Losol.Communication.Sms.Twilio/TwilioSmsSender.cs
@@ -1,6 +1,12 @@
-﻿using Microsoft.Extensions.Options;
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
+using Microsoft.Extensions.Logging;
 using Twilio;
+using Twilio.Exceptions;
 using Twilio.Rest.Api.V2010.Account;
 using Twilio.Types;
 
@@ -8,21 +14,80 @@ namespace Losol.Communication.Sms.Twilio
 {
     public class TwilioSmsSender : ISmsSender
     {
-        private readonly TwilioOptions _options;
+        private readonly IOptions<TwilioOptions> _options;
+        private readonly IHealthCheckStorage _healthCheckStorage;
+        private readonly ILogger<TwilioSmsSender> _logger;
 
-        public TwilioSmsSender(IOptions<TwilioOptions> options)
+        public TwilioSmsSender(
+            IOptions<TwilioOptions> options,
+            IHealthCheckStorage healthCheckStorage,
+            ILogger<TwilioSmsSender> logger)
         {
-            _options = options.Value;
-            TwilioClient.Init(_options.Sid, _options.AuthToken);
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _healthCheckStorage = healthCheckStorage ?? throw new ArgumentNullException(nameof(healthCheckStorage));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            TwilioClient.Init(_options.Value.Sid, _options.Value.AuthToken);
         }
 
         public async Task SendSmsAsync(string to, string body)
         {
-            await MessageResource.CreateAsync(
-                new PhoneNumber(to),
-                from: new PhoneNumber(_options.From),
-                body: body
-            );
+            if (string.IsNullOrWhiteSpace(to))
+            {
+                throw new ArgumentException(nameof(to));
+            }
+
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                throw new ArgumentException(nameof(body));
+            }
+
+            try
+            {
+                var messageResource = await MessageResource.CreateAsync(
+                    new PhoneNumber(to),
+                    @from: new PhoneNumber(_options.Value.From),
+                    body: body
+                );
+
+                _logger.LogDebug("Sent message to {to}; message Sid: {sid}",
+                    to, messageResource.Sid);
+
+                await _healthCheckStorage.CheckedAsync(ISmsSender.ServiceName,
+                    new HealthCheckStatus(HealthStatus.Healthy));
+            }
+            catch (ApiException e)
+            {
+                _logger.LogError(e, "Failed to send SMS to {to}, Twilio Error {code} - {info}", to, e.Code, e.MoreInfo);
+
+                await _healthCheckStorage.CheckedAsync(ISmsSender.ServiceName,
+                    new HealthCheckStatus(HealthStatus.Unhealthy, e.Message));
+
+                throw new SmsSenderException($"Failed to send SMS to {to}", e);
+            }
+        }
+
+        public async Task<HealthCheckStatus> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            _logger.LogInformation("Making Twilio service health check");
+
+            try
+            {
+                _logger.LogDebug("Getting 1 message from twilio");
+                var resource = await MessageResource.ReadAsync(new ReadMessageOptions
+                {
+                    Limit = 1
+                });
+                _logger.LogDebug("Successfully read {num} messages", resource.Count());
+
+                _logger.LogInformation("Health check passed");
+                return new HealthCheckStatus(HealthStatus.Healthy);
+            }
+            catch (ApiException e)
+            {
+                _logger.LogError(e, "Twilio service health check failed: {code} - {info}", e.Code, e.MoreInfo);
+                return new HealthCheckStatus(HealthStatus.Unhealthy, e.MoreInfo);
+            }
         }
     }
 }

--- a/src/Losol.Communication.Sms/ISmsSender.cs
+++ b/src/Losol.Communication.Sms/ISmsSender.cs
@@ -1,14 +1,18 @@
 ﻿using System.Threading.Tasks;
+using Losol.Communication.HealthCheck.Abstractions;
 
 namespace Losol.Communication.Sms
 {
-    public interface ISmsSender
+    public interface ISmsSender : IHealthCheckService
     {
+        const string ServiceName = "sms";
+
         /// <summary>
         /// Sends an SMS asynchronously.
         /// </summary>
         /// <param name="to">The E.164 formatted phone number to send the SMS to.</param>
         /// <param name="body">The SMS body text.</param>
+        /// <exception cref="SmsSenderException">Failed to send SMS</exception>
         Task SendSmsAsync(string to, string body);
     }
 }

--- a/src/Losol.Communication.Sms/SmsSenderException.cs
+++ b/src/Losol.Communication.Sms/SmsSenderException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Losol.Communication.Sms
+{
+    public class SmsSenderException : Exception
+    {
+        public SmsSenderException(string message) : base(message)
+        {
+        }
+
+        public SmsSenderException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>Andrew Anisimov, Ole Kristian Losvik</Authors>
     <Company>Losol AS</Company>
     <IsPackable>true</IsPackable>

--- a/tests/Losol.Communication.HealthCheck.Abstractions.Tests/Losol.Communication.HealthCheck.Abstractions.Tests.csproj
+++ b/tests/Losol.Communication.HealthCheck.Abstractions.Tests/Losol.Communication.HealthCheck.Abstractions.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Losol.Communication.HealthCheck.Abstractions\Losol.Communication.HealthCheck.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Losol.Communication.HealthCheck.Abstractions.Tests/PeriodicHealthCheckTests.cs
+++ b/tests/Losol.Communication.HealthCheck.Abstractions.Tests/PeriodicHealthCheckTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using Xunit;
+
+namespace Losol.Communication.HealthCheck.Abstractions.Tests
+{
+    public class PeriodicHealthCheckTests
+    {
+        private readonly Mock<IHealthCheckService> _serviceMock = new Mock<IHealthCheckService>();
+        private readonly Mock<IHealthCheckStorage> _storageMock = new Mock<IHealthCheckStorage>();
+
+        [Fact]
+        public async Task Should_Check_Status_If_No_Current()
+        {
+            _storageMock.Setup(s => s.GetCurrentStatusAsync(It.IsAny<string>()))
+                .ReturnsAsync((HealthCheckStatus)null);
+
+            var healthCheckStatus = new HealthCheckStatus(HealthStatus.Healthy);
+            _serviceMock.Setup(s => s.CheckHealthAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(healthCheckStatus);
+
+            var check = new TestPeriodicHealthCheck(_storageMock.Object, _serviceMock.Object, TimeSpan.FromMinutes(1));
+            var status = await check.CheckHealthAsync(new HealthCheckContext());
+            Assert.Equal(Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy, status.Status);
+            Assert.Null(status.Exception);
+            Assert.Null(status.Description);
+
+            _serviceMock.Verify(s => s.CheckHealthAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _storageMock.Verify(s => s.CheckedAsync(TestPeriodicHealthCheck.CheckServiceName, healthCheckStatus), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Check_Status_If_Outdated()
+        {
+            var oldHealthCheckStatus =
+                new HealthCheckStatus(HealthStatus.Unhealthy, "Some error message")
+                {
+                    DateTime = DateTime.UtcNow.AddMinutes(-2)
+                };
+
+            _storageMock.Setup(s => s.GetCurrentStatusAsync(It.IsAny<string>()))
+                .ReturnsAsync(oldHealthCheckStatus);
+
+            var newHealthCheckStatus = new HealthCheckStatus(HealthStatus.Healthy);
+            _serviceMock.Setup(s => s.CheckHealthAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newHealthCheckStatus);
+
+            var check = new TestPeriodicHealthCheck(_storageMock.Object, _serviceMock.Object, TimeSpan.FromMinutes(1));
+            var status = await check.CheckHealthAsync(new HealthCheckContext());
+            Assert.Equal(Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy, status.Status);
+            Assert.Null(status.Exception);
+            Assert.Null(status.Description);
+
+            _serviceMock.Verify(s => s.CheckHealthAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _storageMock.Verify(s => s.CheckedAsync(TestPeriodicHealthCheck.CheckServiceName, newHealthCheckStatus), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Not_Check_Status_If_Not_Outdated()
+        {
+            var oldHealthCheckStatus =
+                new HealthCheckStatus(HealthStatus.Unhealthy, "Some error message")
+                {
+                    DateTime = DateTime.UtcNow.AddSeconds(-30)
+                };
+
+            _storageMock.Setup(s => s.GetCurrentStatusAsync(It.IsAny<string>()))
+                .ReturnsAsync(oldHealthCheckStatus);
+
+            var check = new TestPeriodicHealthCheck(_storageMock.Object, _serviceMock.Object, TimeSpan.FromMinutes(1));
+            var status = await check.CheckHealthAsync(new HealthCheckContext());
+            Assert.Equal(Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy, status.Status);
+            Assert.Null(status.Exception);
+            Assert.Equal(oldHealthCheckStatus.ErrorMessage, status.Description);
+
+            _serviceMock.Verify(s => s.CheckHealthAsync(It.IsAny<CancellationToken>()), Times.Never);
+            _storageMock.Verify(s => s.CheckedAsync(It.IsAny<string>(), It.IsAny<HealthCheckStatus>()), Times.Never);
+        }
+    }
+}

--- a/tests/Losol.Communication.HealthCheck.Abstractions.Tests/TestPeriodicHealthCheck.cs
+++ b/tests/Losol.Communication.HealthCheck.Abstractions.Tests/TestPeriodicHealthCheck.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Losol.Communication.HealthCheck.Abstractions.Tests
+{
+    public class TestPeriodicHealthCheck : AbstractPeriodicHealthCheck
+    {
+        public const string CheckServiceName = "test";
+
+        public TestPeriodicHealthCheck(
+            IHealthCheckStorage healthCheckStorage,
+            IHealthCheckService healthCheckService,
+            TimeSpan checkPeriod) : base(healthCheckStorage, healthCheckService)
+        {
+            CheckPeriod = checkPeriod;
+        }
+
+        protected override string ServiceName => CheckServiceName;
+
+        protected override TimeSpan CheckPeriod { get; }
+    }
+}


### PR DESCRIPTION
Email service periodic check allows to monitor SMTP/SendGrid service status.
It's done once in a predefined amount of time (configured via settings),
also it's done when actually sending email.

+ Similar check for SMS services.

TODO: SendGrid health check.

Release Notes:

IEmailSender.SendEmailAsync() and ISmsSender.SendSmsAsync() both now throw exceptions in case of an unsuccessful delivery (EmailSenderException + SmsSenderException). 