### PR TITLE
Fix issues in HealthCheckMemoryStorage

### DIFF
--- a/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckMemoryStorage.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckMemoryStorage.cs
@@ -1,26 +1,38 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
 namespace Losol.Communication.HealthCheck.Abstractions
 {
     public class HealthCheckMemoryStorage : IHealthCheckStorage
     {
-        private readonly IDictionary<string, HealthCheckStatus> _checks =
-            new Dictionary<string, HealthCheckStatus>();
+        private readonly ConcurrentDictionary<string, HealthCheckStatus> _checks =
+            new ConcurrentDictionary<string, HealthCheckStatus>();
 
         public Task<HealthCheckStatus> GetCurrentStatusAsync(string serviceName)
         {
-            return Task.FromResult(_checks.ContainsKey(serviceName) ? _checks[serviceName] : null);
+            if (_checks.TryGetValue(serviceName, out var status))
+            {
+                return Task.FromResult(status);
+            }
+            return Task.FromResult((HealthCheckStatus)null);
         }
 
-        public Task CheckedAsync(string serviceName, HealthCheckStatus healthCheckStatus)
+        public Task CheckedAsync(string serviceName, HealthCheckStatus newStatus)
         {
             if (string.IsNullOrWhiteSpace(serviceName))
             {
                 throw new ArgumentException(nameof(serviceName));
             }
-            _checks.Add(serviceName, healthCheckStatus ?? throw new ArgumentNullException(nameof(healthCheckStatus)));
+
+            if (newStatus == null)
+            {
+                throw new ArgumentNullException(nameof(newStatus));
+            }
+
+            _checks.AddOrUpdate(serviceName, newStatus, (key, existingStatus) =>
+                existingStatus.DateTime > newStatus.DateTime ? existingStatus : newStatus);
+
             return Task.CompletedTask;
         }
     }

--- a/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckStatus.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/HealthCheckStatus.cs
@@ -15,5 +15,23 @@ namespace Losol.Communication.HealthCheck.Abstractions
             Status = status;
             ErrorMessage = errorMessage;
         }
+
+        protected bool Equals(HealthCheckStatus other)
+        {
+            return Status == other.Status && DateTime.Equals(other.DateTime) && ErrorMessage == other.ErrorMessage;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((HealthCheckStatus)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine((int)Status, DateTime, ErrorMessage);
+        }
     }
 }

--- a/src/Losol.Communication.HealthCheck.Abstractions/IHealthCheckStorage.cs
+++ b/src/Losol.Communication.HealthCheck.Abstractions/IHealthCheckStorage.cs
@@ -6,6 +6,6 @@ namespace Losol.Communication.HealthCheck.Abstractions
     {
         Task<HealthCheckStatus> GetCurrentStatusAsync(string serviceName);
 
-        Task CheckedAsync(string serviceName, HealthCheckStatus healthCheckStatus);
+        Task CheckedAsync(string serviceName, HealthCheckStatus newStatus);
     }
 }

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Andrew Anisimov, Ole Kristian Losvik</Authors>
     <Company>Losol AS</Company>
     <IsPackable>true</IsPackable>

--- a/tests/Losol.Communication.HealthCheck.Abstractions.Tests/HealthCheckStorageTests.cs
+++ b/tests/Losol.Communication.HealthCheck.Abstractions.Tests/HealthCheckStorageTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Losol.Communication.HealthCheck.Abstractions.Tests
+{
+    public class HealthCheckStorageTests
+    {
+        [Theory]
+        [MemberData(nameof(GetStorage))]
+        public async Task Should_Return_Null_When_Getting_Status_Without_Check_Performed(IHealthCheckStorage storage)
+        {
+            Assert.Null(await storage.GetCurrentStatusAsync("test"));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetStorage))]
+        public async Task Should_Store_Checks_For_Separate_Services(IHealthCheckStorage storage)
+        {
+            var unhealthy = new HealthCheckStatus(HealthStatus.Unhealthy);
+            var healthy = new HealthCheckStatus(HealthStatus.Healthy);
+
+            await storage.CheckedAsync("s1", unhealthy);
+            await storage.CheckedAsync("s2", healthy);
+
+            Assert.Equal(unhealthy, await storage.GetCurrentStatusAsync("s1"));
+            Assert.Equal(healthy, await storage.GetCurrentStatusAsync("s2"));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetStorage))]
+        public async Task Should_Not_Replace_Newest_Value(IHealthCheckStorage storage)
+        {
+            var olderCheck = new HealthCheckStatus(HealthStatus.Unhealthy) { DateTime = DateTime.UtcNow.AddSeconds(-1) };
+            var newerCheck = new HealthCheckStatus(HealthStatus.Healthy);
+
+            await storage.CheckedAsync("test", newerCheck);
+            Assert.Equal(newerCheck, await storage.GetCurrentStatusAsync("test"));
+
+            await storage.CheckedAsync("test", olderCheck);
+            Assert.Equal(newerCheck, await storage.GetCurrentStatusAsync("test"));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetStorage))]
+        public async Task Should_Replace_Older_Value(IHealthCheckStorage storage)
+        {
+            var olderCheck = new HealthCheckStatus(HealthStatus.Unhealthy) { DateTime = DateTime.UtcNow.AddSeconds(-1) };
+            var newerCheck = new HealthCheckStatus(HealthStatus.Healthy);
+
+            await storage.CheckedAsync("test", olderCheck);
+            Assert.Equal(olderCheck, await storage.GetCurrentStatusAsync("test"));
+
+            await storage.CheckedAsync("test", newerCheck);
+            Assert.Equal(newerCheck, await storage.GetCurrentStatusAsync("test"));
+        }
+
+        public static object[][] GetStorage()
+        {
+            return new[]
+            {
+                new object[] {new HealthCheckMemoryStorage(),},
+            };
+        }
+    }
+}


### PR DESCRIPTION
1. It couldn't add new status check second time. Was throwing exception.
2. It wasn't handling concurrent scenarios.

+ unit tests