### PR TITLE
Email sender issues

### DIFF
--- a/src/Losol.Communication.Email.SendGrid/SendGridConfig.cs
+++ b/src/Losol.Communication.Email.SendGrid/SendGridConfig.cs
@@ -5,8 +5,6 @@ namespace Losol.Communication.Email.SendGrid
     public class SendGridConfig
     {
         [Required]
-        public string User { get; set; }
-        [Required]
         public string Key { get; set; }
         [Required]
         public string EmailAddress { get; set; }

--- a/src/Losol.Communication.Email.SendGrid/SendGridEmailSender.cs
+++ b/src/Losol.Communication.Email.SendGrid/SendGridEmailSender.cs
@@ -56,7 +56,8 @@ namespace Losol.Communication.Email.SendGrid
 
             var client = new SendGridClient(_config.Key);
             var response = await client.SendEmailAsync(msg);
-            if (response.StatusCode != HttpStatusCode.OK)
+            if (response.StatusCode != HttpStatusCode.OK &&
+                response.StatusCode != HttpStatusCode.Accepted)
             {
                 var responseBody = await response.Body.ReadAsStringAsync();
                 throw new EmailSenderException($"SendGrid returned {response.StatusCode} status code ({responseBody})");

--- a/src/Losol.Communication.Email.Smtp/SmtpConfig.cs
+++ b/src/Losol.Communication.Email.Smtp/SmtpConfig.cs
@@ -8,7 +8,8 @@ namespace Losol.Communication.Email.Smtp
         public string Host { get; set; }
         public int Port { get; set; } = 587;
         [Required]
-        public string From { get; set; }
+        public string FromEmail { get; set; }
+        public string FromName { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
     }

--- a/src/Losol.Communication.Email.Smtp/SmtpEmailSender.cs
+++ b/src/Losol.Communication.Email.Smtp/SmtpEmailSender.cs
@@ -35,7 +35,7 @@ namespace Losol.Communication.Email.Smtp
 
             mimeMessage.From.Add(emailModel.From != null
                 ? new MailboxAddress(Encoding.UTF8, emailModel.From.Name, emailModel.From.Email)
-                : new MailboxAddress(_smtpConfig.From));
+                : new MailboxAddress(Encoding.UTF8, _smtpConfig.FromName, _smtpConfig.FromEmail));
 
             mimeMessage.To.AddRange(emailModel.Recipients.Select(a => new MailboxAddress(Encoding.UTF8, a.Name, a.Email)));
 


### PR DESCRIPTION
 **Fixes in SendGrid email sender**
    
    1. Don't fire exception on 202 (Accepted) status code returned by SendGrid.
    
    2. Remove unused (but required) User property from SendGridConfig.

 **Fixes in SMTP email sender.**
    
    Changes in smtp config: Separate From name and From email fields.
    
    From name is optional, while from email is required.